### PR TITLE
compilation error fixed	

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,16 @@
+Download NDK and extract it and rename it to ndk
+
+go to kernel root source
+
+open terminal and type
+
+export CROSS_COMPILE=/home/hardik/Documents/ndk/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/bin/aarch64-linux-android-
+
+
+make clean && make mrproper
+
+export ARCH=arm64
+
+make gionee6753_65u_m0_defconfig
+
+make ARCH=arm64

--- a/drivers/misc/mediatek/base/power/mt6735/mt_pbm.c
+++ b/drivers/misc/mediatek/base/power/mt6735/mt_pbm.c
@@ -20,8 +20,8 @@
 #include <mach/mt_pbm.h>
 #include <mach/upmu_sw.h>
 #include <mt-plat/upmu_common.h>
-#include <mt_cpufreq.h>
-#include <mt_gpufreq.h>
+#include "mt_cpufreq.h"
+#include "mt_gpufreq.h"
 #include <mach/mt_thermal.h>
 
 #ifndef DISABLE_PBM_FEATURE

--- a/drivers/misc/mediatek/base/power/mt6735/mt_pm_init.c
+++ b/drivers/misc/mediatek/base/power/mt6735/mt_pm_init.c
@@ -30,7 +30,7 @@
 /* #include "mach/mt_cpufreq.h" */
 /* #include "mach/mt_gpufreq.h" */
 #include "mt_cpuidle.h"
-#include <mt_clkbuf_ctl.h>
+#include "mt_clkbuf_ctl.h"
 /* #include "mach/mt_clkbuf_ctl.h" */
 /* #include "mach/mt_chip.h" */
 #include "mt-plat/mtk_rtc.h"

--- a/drivers/misc/mediatek/base/power/mt6735/mt_ptp.c
+++ b/drivers/misc/mediatek/base/power/mt6735/mt_ptp.c
@@ -145,7 +145,7 @@ unsigned int reg_dump_addr_off[] = {
 #include <linux/of_fdt.h>
 #endif
 /* local includes */
-#include <mt_spm.h>
+#include "mt_spm.h"
 #include "aee.h"
 #include <linux/gpio.h>
 

--- a/drivers/misc/mediatek/btcvsd/inc/mt6735/AudDrv_BTCVSD.h
+++ b/drivers/misc/mediatek/btcvsd/inc/mt6735/AudDrv_BTCVSD.h
@@ -2,7 +2,7 @@
 #define AUDDRV_BTCVSD_H
 
 #include <linux/types.h>
-#include "AudioBTCVSDDef.h"
+#include "../../AudioBTCVSDDef.h"
 
 #undef DEBUG_AUDDRV
 #ifdef DEBUG_AUDDRV

--- a/drivers/misc/mediatek/cmdq/v2/cmdq_def.h
+++ b/drivers/misc/mediatek/cmdq/v2/cmdq_def.h
@@ -9,7 +9,7 @@
 #ifdef CMDQ_COMMON_ENG_SUPPORT
 #include "cmdq_engine_common.h"
 #else
-#include "cmdq_engine.h"
+#include "./mt6735/cmdq_engine.h"
 #endif
 
 #define CMDQ_SPECIAL_SUBSYS_ADDR (99)

--- a/drivers/misc/mediatek/ext_disp/extd_factory.c
+++ b/drivers/misc/mediatek/ext_disp/extd_factory.c
@@ -4,7 +4,8 @@
 #include "extd_log.h"
 #include "extd_factory.h"
 #include "extd_info.h"
-#include "external_display.h"
+#include "./mt6735/external_display.h"
+
 
 #include "dpi_dvt_test.h"
 

--- a/drivers/misc/mediatek/ext_disp/extd_multi_control.c
+++ b/drivers/misc/mediatek/ext_disp/extd_multi_control.c
@@ -3,8 +3,8 @@
 
 #include "extd_multi_control.h"
 #include "disp_drv_platform.h"
-#include "external_display.h"
-#include "extd_platform.h"
+#include "./mt6735/external_display.h"
+#include "./mt6735/extd_platform.h"
 #include "extd_log.h"
 #include "mtk_ovl.h"
 

--- a/drivers/misc/mediatek/gpio/mt6735/6735_gpio.h
+++ b/drivers/misc/mediatek/gpio/mt6735/6735_gpio.h
@@ -1,7 +1,7 @@
 #ifndef _6735_GPIO_H
 #define _6735_GPIO_H
 
-#include <mt_gpio_base.h>
+#include "mt_gpio_base.h"
 #include <linux/slab.h>
 #include <linux/device.h>
 

--- a/drivers/misc/mediatek/gpio/mt6735/mt_gpio_affix.c
+++ b/drivers/misc/mediatek/gpio/mt6735/mt_gpio_affix.c
@@ -5,7 +5,7 @@
 #include <linux/device.h>
 /* #include <mach/mt_gpio.h> */
 #include <mt-plat/mt_gpio_core.h>
-#include <6735_gpio.h>
+#include "6735_gpio.h"
 
 
 void mt_gpio_pin_decrypt(unsigned long *cipher)

--- a/drivers/misc/mediatek/gpio/mt6735/mt_gpio_base.c
+++ b/drivers/misc/mediatek/gpio/mt6735/mt_gpio_base.c
@@ -9,14 +9,14 @@
  ******************************************************************************/
 
 
-#include <6735_gpio.h>
+#include "6735_gpio.h"
 #include <linux/types.h>
 #include "mt-plat/sync_write.h"
 #include <mt-plat/mt_gpio.h>
 #include <mt-plat/mt_gpio_core.h>
-#include <mt_gpio_base.h>
+#include "mt_gpio_base.h"
 /* autogen */
-#include <gpio_cfg.h>
+#include "gpio_cfg.h"
 #ifdef CONFIG_OF
 #include <linux/of_address.h>
 #endif

--- a/drivers/misc/mediatek/gpio/mt6735/mt_gpio_base_linux.c
+++ b/drivers/misc/mediatek/gpio/mt6735/mt_gpio_base_linux.c
@@ -6,7 +6,7 @@
 #include <linux/platform_device.h>
 #include <linux/seq_file.h>
 
-#include <mt_gpio_base.h>
+#include "mt_gpio_base.h"
 #include <mt-plat/mt_gpio_core.h>
 /*#include <mach/eint.h>*/
 #include <linux/interrupt.h>

--- a/drivers/misc/mediatek/gpio/mt6735/mt_gpio_debug.c
+++ b/drivers/misc/mediatek/gpio/mt6735/mt_gpio_debug.c
@@ -9,7 +9,7 @@
  ******************************************************************************/
 
 #include <linux/slab.h>
-#include <6735_gpio.h>
+#include "6735_gpio.h"
 #include <mt-plat/mt_gpio.h>
 #include <mt-plat/mt_gpio_core.h>
 

--- a/drivers/misc/mediatek/gpio/mt6735/mt_gpio_ext.c
+++ b/drivers/misc/mediatek/gpio/mt6735/mt_gpio_ext.c
@@ -10,7 +10,7 @@
 
 #include <mt-plat/mt_gpio.h>
 #include <mt-plat/mt_gpio_core.h>
-#include <mt_gpio_ext.h>
+#include "mt_gpio_ext.h"
 
 /* #define MAX_GPIO_REG_BITS      16 */
 /* #define MAX_GPIO_MODE_PER_REG  5 */

--- a/drivers/misc/mediatek/i2c/mt6735/i2c.c
+++ b/drivers/misc/mediatek/i2c/mt6735/i2c.c
@@ -25,7 +25,7 @@
 #include <asm/io.h>
 /* #include <mach/dma.h> */
 /* #include <mach/mt_reg_base.h> */
-#include <mt_i2c.h>
+#include "mt_i2c.h"
 #include <mt-plat/sync_write.h>
 #include "../../base/power/mt6735/mt_pm_init.h"
 /* #include "mach/memory.h" */

--- a/drivers/misc/mediatek/i2c/mt6735/i2c_common.c
+++ b/drivers/misc/mediatek/i2c/mt6735/i2c_common.c
@@ -8,7 +8,7 @@
 #include <linux/err.h>
 /* #include <mach/mt_pm_ldo.h> */
 #include <asm/memory.h>
-#include <mt_i2c.h>
+#include "mt_i2c.h"
 
 static char data_buffer[256 * 4];
 
@@ -438,7 +438,7 @@ static DEVICE_ATTR(ut, 0660, show_config, set_config);
 static int i2c_common_probe(struct platform_device *pdev)
 {
 	int ret = 0;
-	/* your code here£¬your should save client in your own way */
+	/* your code here\A3\ACyour should save client in your own way */
 	I2CLOG("i2c_common device probe\n");
 	ret = device_create_file(&pdev->dev, &dev_attr_ut);
 	return ret;

--- a/drivers/misc/mediatek/include/mt-plat/mt6735/include/mach/mt_gpufreq.h
+++ b/drivers/misc/mediatek/include/mt-plat/mt6735/include/mach/mt_gpufreq.h
@@ -1,0 +1,115 @@
+#ifndef _MT_GPUFREQ_H
+#define _MT_GPUFREQ_H
+
+#include <linux/module.h>
+
+/*
+ * CONFIG
+ */
+/**************************************************
+ * Define low battery voltage support
+ ***************************************************/
+#define MT_GPUFREQ_LOW_BATT_VOLT_PROTECT
+
+/**************************************************
+ * Define low battery volume support
+ ***************************************************/
+#define MT_GPUFREQ_LOW_BATT_VOLUME_PROTECT
+
+/**************************************************
+ * Define oc support
+ ***************************************************/
+/* #define MT_GPUFREQ_OC_PROTECT */
+
+/**************************************************
+ * VCORE DVFS option
+ ***************************************************/
+#define MT_GPUFREQ_VCOREFS_ENABLED
+
+/**************************************************
+ * GPU DVFS input boost feature
+ ***************************************************/
+#define MT_GPUFREQ_INPUT_BOOST
+
+/***************************
+ * Define for dynamic power table update
+ ****************************/
+#define MT_GPUFREQ_DYNAMIC_POWER_TABLE_UPDATE
+
+/***************************
+ * Define for random test
+ ****************************/
+/* #define MT_GPU_DVFS_RANDOM_TEST */
+
+/***************************
+ * Define for performance test
+ ****************************/
+/* #define MT_GPUFREQ_PERFORMANCE_TEST */
+
+/***************************
+ * Define for SRAM debugging
+ ****************************/
+#ifdef CONFIG_MTK_RAM_CONSOLE
+#define MT_GPUFREQ_AEE_RR_REC
+#endif
+
+/**********************************
+ * Power table struct for thermal
+ **********************************/
+struct mt_gpufreq_power_table_info {
+	unsigned int gpufreq_khz;
+	unsigned int gpufreq_volt;
+	unsigned int gpufreq_power;
+};
+
+
+/******************************
+ * Forward ref
+ *******************************/
+extern u32 get_devinfo_with_index(u32 index);
+#ifdef MT_GPUFREQ_AEE_RR_REC
+extern void aee_rr_rec_gpu_dvfs_vgpu(u8 val);
+extern void aee_rr_rec_gpu_dvfs_oppidx(u8 val);
+extern void aee_rr_rec_gpu_dvfs_status(u8 val);
+extern u8 aee_rr_curr_gpu_dvfs_status(void);
+#endif
+
+/*****************
+ * extern function
+ ******************/
+/* extern int mt_gpufreq_state_set(int enabled); */
+extern unsigned int mt_gpufreq_get_cur_freq_index(void);
+extern unsigned int mt_gpufreq_get_cur_freq(void);
+extern unsigned int mt_gpufreq_get_cur_volt(void);
+extern unsigned int mt_gpufreq_get_dvfs_table_num(void);
+extern int mt_gpufreq_target(unsigned int idx);
+extern int mt_gpufreq_voltage_enable_set(unsigned int enable);
+extern unsigned int mt_gpufreq_get_freq_by_idx(unsigned int idx);
+extern void mt_gpufreq_thermal_protect(unsigned int limited_power);
+extern unsigned int mt_gpufreq_get_max_power(void);
+extern unsigned int mt_gpufreq_get_min_power(void);
+extern unsigned int mt_gpufreq_get_thermal_limit_index(void);
+extern unsigned int mt_gpufreq_get_thermal_limit_freq(void);
+extern void mt_gpufreq_set_power_limit_by_pbm(unsigned int limited_power);
+extern unsigned int mt_gpufreq_get_leakage_mw(void);
+
+/*****************
+ * power limit notification
+ ******************/
+typedef void (*gpufreq_power_limit_notify) (unsigned int);
+extern void mt_gpufreq_power_limit_notify_registerCB(gpufreq_power_limit_notify pCB);
+
+/*****************
+ * input boost notification
+ ******************/
+typedef void (*gpufreq_input_boost_notify) (unsigned int);
+extern void mt_gpufreq_input_boost_notify_registerCB(gpufreq_input_boost_notify pCB);
+
+/*****************
+ * profiling purpose
+ ******************/
+typedef void (*sampler_func) (unsigned int);
+extern void mt_gpufreq_setfreq_registerCB(sampler_func pCB);
+extern void mt_gpufreq_setvolt_registerCB(sampler_func pCB);
+
+#endif

--- a/drivers/misc/mediatek/include/mt-plat/mt6735/include/mach/mt_thermal.h
+++ b/drivers/misc/mediatek/include/mt-plat/mt6735/include/mach/mt_thermal.h
@@ -13,7 +13,7 @@
 #include "mt-plat/sync_write.h"
 #include "mtk_thermal_typedefs.h"
 #include "mt-plat/mtk_mdm_monitor.h"
-#include "mt_gpufreq.h"
+#include "../../../../../base/power/mt6735/mt_gpufreq.h"
 /* #include "mach/mt6575_auxadc_hw.h" */
 
 #if !defined(CONFIG_MTK_LEGACY)

--- a/drivers/misc/mediatek/include/mt-plat/sd_misc.h
+++ b/drivers/misc/mediatek/include/mt-plat/sd_misc.h
@@ -10,7 +10,8 @@
 #include <linux/mmc/sd.h>
 #endif
 
-#include <mt_sd.h>
+
+#include "../../../../mmc/host/mediatek/mt6735/mt_sd.h"
 
 #ifndef FPGA_PLATFORM
 extern void msdc_set_driving(struct msdc_host *host, struct msdc_hw *hw, bool sd_18);

--- a/drivers/misc/mediatek/m4u/2.0/m4u_pgtable.h
+++ b/drivers/misc/mediatek/m4u/2.0/m4u_pgtable.h
@@ -1,7 +1,7 @@
 #ifndef __M4U_PGTABLE_H__
 #define __M4U_PGTABLE_H__
 
-#include "m4u_reg.h"
+#include "../mt6735/mt6753/m4u_reg.h"
 
 /* ================================================================= */
 /* 2 level pagetable: pgd -> pte */

--- a/drivers/misc/mediatek/m4u/mt6735/m4u_priv.h
+++ b/drivers/misc/mediatek/m4u/mt6735/m4u_priv.h
@@ -12,9 +12,9 @@
 #endif
 
 #include "m4u.h"
-#include "m4u_reg.h"
+#include "./mt6753/m4u_reg.h"
 #include "../2.0/m4u_pgtable.h"
-#include "m4u_platform.h"
+#include "./mt6753/m4u_platform.h"
 
 #define M4UMSG(string, args...)	pr_err("M4U"string, ##args)
 #define M4UINFO(string, args...) pr_debug("M4U"string, ##args)

--- a/drivers/misc/mediatek/power/mt6735/mt6311.c
+++ b/drivers/misc/mediatek/power/mt6735/mt6311.c
@@ -27,7 +27,7 @@
 /*#include <mach/eint.h> TBD*/
 
 #include <mt-plat/upmu_common.h>
-#include <mt6311.h>
+#include "mt6311.h"
 
 #include <mach/mt_pmic.h>
 

--- a/drivers/misc/mediatek/power/mt6735/pmic.c
+++ b/drivers/misc/mediatek/power/mt6735/pmic.c
@@ -65,7 +65,7 @@
 #include <linux/gpio/consumer.h>
 #endif
 #include <mt-plat/upmu_common.h>
-#include <pmic.h>
+#include "pmic.h"
 /*#include <mach/eint.h> TBD*/
 #include <mach/mt_pmic_wrap.h>
 #if defined CONFIG_MTK_LEGACY
@@ -88,7 +88,7 @@
 #include <mt-plat/battery_common.h>
 #include <mach/mt_battery_meter.h>
 #endif
-#include <mt6311.h>
+#include "mt6311.h"
 #include <mach/mt_pmic.h>
 
 #include <mt-plat/aee.h>

--- a/drivers/misc/mediatek/uart/include/mtk_uart.h
+++ b/drivers/misc/mediatek/uart/include/mtk_uart.h
@@ -5,7 +5,7 @@
 #include <mach/mt_reg_base.h>
 #endif
 #include <mt-plat/sync_write.h>
-#include "platform_uart.h"
+#include "../mt6735/platform_uart.h"
 
 /*---------------------------------------------------------------------------*/
 #if defined(ENABLE_VFIFO_DEBUG)

--- a/drivers/misc/mediatek/uart/include/mtk_uart_intf.h
+++ b/drivers/misc/mediatek/uart/include/mtk_uart_intf.h
@@ -1,7 +1,7 @@
 #ifndef __MTK_UART_INTF_H__
 #define __MTK_UART_INTF_H__
 
-#include "platform_uart.h"
+#include "../mt6735/platform_uart.h"
 #include <linux/platform_device.h>
 /*---------------------------------------------------------------------------*/
 /* fiq debugger */

--- a/drivers/misc/mediatek/video/common/mtkfb_fence.h
+++ b/drivers/misc/mediatek/video/common/mtkfb_fence.h
@@ -5,7 +5,7 @@
 #include <linux/list.h>
 #include "disp_session.h"
 #include "disp_drv_platform.h"
-#include "display_recorder.h"
+#include "../mt6735/dispsys/display_recorder.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/misc/mediatek/video/common/rdma10/ddp_rdma.h
+++ b/drivers/misc/mediatek/video/common/rdma10/ddp_rdma.h
@@ -4,8 +4,9 @@
 #include <mt-plat/sync_write.h>
 #include <linux/types.h>
 /* #include <mach/mt_reg_base.h> */
-#include "ddp_info.h"
-#include "ddp_hal.h"
+#include "../../mt6735/dispsys/ddp_info.h"
+#include "../../mt6735/dispsys/ddp_hal.h"
+
 
 extern unsigned long long rdma_start_time[];
 extern unsigned long long rdma_end_time[];

--- a/drivers/misc/mediatek/video/common/wdma10/ddp_wdma.h
+++ b/drivers/misc/mediatek/video/common/wdma10/ddp_wdma.h
@@ -1,8 +1,8 @@
 #ifndef _DDP_WDMA_H_
 #define _DDP_WDMA_H_
 
-#include "ddp_hal.h"
-#include "ddp_info.h"
+#include "../../mt6735/dispsys/ddp_hal.h"
+#include "../../mt6735/dispsys/ddp_info.h"
 
 /* start module */
 int wdma_start(DISP_MODULE_ENUM module, void *handle);

--- a/drivers/misc/mediatek/video/mt6735/dispsys/ddp_pwm_mux.c
+++ b/drivers/misc/mediatek/video/mt6735/dispsys/ddp_pwm_mux.c
@@ -1,6 +1,6 @@
 #include <linux/kernel.h>
 #include <linux/clk.h>
-#include <ddp_drv.h>
+#include "ddp_drv.h"
 #include <ddp_pwm_mux.h>
 #include <linux/of.h>
 #include <linux/of_address.h>

--- a/drivers/misc/mediatek/video/mt6735/dispsys/mt6753/ddp_ovl.h
+++ b/drivers/misc/mediatek/video/mt6735/dispsys/mt6753/ddp_ovl.h
@@ -1,9 +1,9 @@
 #ifndef _DDP_OVL_H_
 #define _DDP_OVL_H_
 
-#include "ddp_hal.h"
+#include "../ddp_hal.h"
 #include "DpDataType.h"
-#include "ddp_info.h"
+#include "../ddp_info.h"
 
 
 #define OVL_MAX_WIDTH  (4095)

--- a/drivers/misc/mediatek/video/mt6735/dispsys/mt6753/ddp_rdma_ex.h
+++ b/drivers/misc/mediatek/video/mt6735/dispsys/mt6753/ddp_rdma_ex.h
@@ -1,6 +1,6 @@
 #ifndef _DDP_RDMA_EX_H_
 #define _DDP_RDMA_EX_H_
-#include "ddp_info.h"
+#include "../ddp_info.h"
 
 #define RDMA_INSTANCES  2
 #define RDMA_MAX_WIDTH  4095

--- a/drivers/misc/mediatek/video/mt6735/dispsys/mt6753/ddp_reg.h
+++ b/drivers/misc/mediatek/video/mt6735/dispsys/mt6753/ddp_reg.h
@@ -3,12 +3,12 @@
 #include <mt-plat/sync_write.h>
 /* #include <mach/mt_reg_base.h> */
 #include <linux/types.h>
-#include "display_recorder.h"
+#include "../display_recorder.h"
 #include "cmdq_record.h"
 #include "cmdq_core.h"
-#include "ddp_hal.h"
-#include "ddp_log.h"
-#include "ddp_path.h"
+#include "../ddp_hal.h"
+#include "../ddp_log.h"
+#include "../ddp_path.h"
 
 /* MIPITX and DSI */
 #define ENABLE_CLK_MGR

--- a/drivers/misc/mediatek/video/mt6735/videox/disp_drv_log.h
+++ b/drivers/misc/mediatek/video/mt6735/videox/disp_drv_log.h
@@ -1,7 +1,7 @@
 #ifndef __DISP_DRV_LOG_H__
 #define __DISP_DRV_LOG_H__
-#include "display_recorder.h"
-#include "ddp_debug.h"
+#include "../dispsys/display_recorder.h"
+#include "../dispsys/ddp_debug.h"
 #include "disp_drv_platform.h"
 
 extern unsigned int dprec_error_log_len;

--- a/drivers/misc/mediatek/video/mt6735/videox/mt6753/disp_drv_platform.h
+++ b/drivers/misc/mediatek/video/mt6735/videox/mt6753/disp_drv_platform.h
@@ -13,11 +13,11 @@
 #endif
 /* #include <mach/mt_irq.h> */
 /*#include <board-custom.h>*/
-#include "disp_assert_layer.h"
+#include "../disp_assert_layer.h"
 #include <mt-plat/sync_write.h>
-#include "ddp_hal.h"
+#include "../ddp_hal.h"
 /* #include "ddp_drv.h" */
-#include "ddp_path.h"
+#include "../ddp_path.h"
 #include "ddp_ovl.h"
 
 

--- a/drivers/misc/mediatek/video/mt6735/videox/primary_display.h
+++ b/drivers/misc/mediatek/video/mt6735/videox/primary_display.h
@@ -1,8 +1,7 @@
 #ifndef _PRIMARY_DISPLAY_H_
 #define _PRIMARY_DISPLAY_H_
-
-#include "ddp_hal.h"
-#include "ddp_manager.h"
+#include "../dispsys/ddp_hal.h"
+#include "../dispsys/ddp_manager.h"
 #include <linux/types.h>
 #include "disp_lcm.h"
 #include "disp_session.h"

--- a/drivers/pinctrl/mediatek/pinctrl-mtk-mt6735.h
+++ b/drivers/pinctrl/mediatek/pinctrl-mtk-mt6735.h
@@ -12,7 +12,7 @@
 #define __PINCTRL_MTK_MT6735_H
 
 #include <linux/pinctrl/pinctrl.h>
-#include <pinctrl-mtk-common.h>
+#include "pinctrl-mtk-common.h"
 
 static const struct mtk_desc_pin mtk_pins_mt6735[] = {
 	MTK_PIN(

--- a/drivers/spi/mediatek/mt6735/spi-dev.c
+++ b/drivers/spi/mediatek/mt6735/spi-dev.c
@@ -4,7 +4,7 @@
 #include <linux/types.h>
 #include <linux/device.h>
 #include <linux/delay.h>
-#include <mt_spi.h>
+#include "mt_spi.h"
 
 #include <linux/dma-mapping.h>
 #include <linux/sched.h>

--- a/drivers/spi/mediatek/mt6735/spi.c
+++ b/drivers/spi/mediatek/mt6735/spi.c
@@ -27,7 +27,7 @@
 #include <linux/of_address.h>
 #endif
 /*#include <mach/irqs.h>*/
-#include <mt_spi.h>
+#include "mt_spi.h"
 #include "mt_spi_hal.h"
 /*#include <mach/mt_gpio.h>*/
 

--- a/drivers/watchdog/mediatek/wdt/mt6735/mtk_wdt.c
+++ b/drivers/watchdog/mediatek/wdt/mt6735/mtk_wdt.c
@@ -11,7 +11,7 @@
 
 #include <asm/uaccess.h>
 #include <linux/types.h>
-#include <mt_wdt.h>
+#include "mt_wdt.h"
 #include <linux/delay.h>
 
 #include <linux/device.h>


### PR DESCRIPTION
…pbm.c

compilation error fixed	  drivers/misc/mediatek/base/power/mt6735/mt_pm_init.c
compilation error fixed	  drivers/misc/mediatek/base/power/mt6735/mt_ptp.c
compilation error fixed	  drivers/misc/mediatek/btcvsd/inc/mt6735/AudDrv_BTCVSD.h
compilation error fixed	  drivers/misc/mediatek/cmdq/v2/cmdq_def.h
compilation error fixed	  drivers/misc/mediatek/ext_disp/extd_factory.c
compilation error fixed	  drivers/misc/mediatek/ext_disp/extd_multi_control.c
compilation error fixed   drivers/misc/mediatek/gpio/mt6735/6735_gpio.h
compilation error fixed	  drivers/misc/mediatek/gpio/mt6735/mt_gpio_affix.c
compilation error fixed	  drivers/misc/mediatek/gpio/mt6735/mt_gpio_base.c
compilation error fixed	  drivers/misc/mediatek/gpio/mt6735/mt_gpio_base_linux.c
compilation error fixed   drivers/misc/mediatek/gpio/mt6735/mt_gpio_debug.c
compilation error fixed   drivers/misc/mediatek/gpio/mt6735/mt_gpio_ext.c
compilation error fixed   drivers/misc/mediatek/i2c/mt6735/i2c.c
compilation error fixed   drivers/misc/mediatek/i2c/mt6735/i2c_common.c
compilation error fixed	  drivers/misc/mediatek/include/mt-plat/mt6735/include/mach/mt_gpufreq.h
compilation error fixed	  drivers/misc/mediatek/include/mt-plat/mt6735/include/mach/mt_thermal.h
compilation error fixed	  drivers/misc/mediatek/include/mt-plat/sd_misc.h
compilation error fixed	  drivers/misc/mediatek/m4u/2.0/m4u_pgtable.h
compilation error fixed	  drivers/misc/mediatek/m4u/mt6735/m4u_priv.h
compilation error fixed	  drivers/misc/mediatek/power/mt6735/mt6311.c
compilation error fixed	  drivers/misc/mediatek/power/mt6735/pmic.c
compilation error fixed	  drivers/misc/mediatek/uart/include/mtk_uart.h
compilation error fixed   drivers/misc/mediatek/uart/include/mtk_uart_intf.h
compilation error fixed   drivers/misc/mediatek/video/common/mtkfb_fence.h
compilation error fixed   drivers/misc/mediatek/video/common/rdma10/ddp_rdma.h
compilation error fixed   drivers/misc/mediatek/video/common/wdma10/ddp_wdma.h
compilation error fixed   drivers/misc/mediatek/video/mt6735/dispsys/ddp_pwm_mux.c
compilation error fixed   drivers/misc/mediatek/video/mt6735/dispsys/mt6753/ddp_ovl.h
compilation error fixed   drivers/misc/mediatek/video/mt6735/dispsys/mt6753/ddp_rdma_ex.h
compilation error fixed   drivers/misc/mediatek/video/mt6735/dispsys/mt6753/ddp_reg.h
compilation error fixed   drivers/misc/mediatek/video/mt6735/videox/disp_drv_log.h
compilation error fixed   drivers/misc/mediatek/video/mt6735/videox/mt6753/disp_drv_platform.h
compilation error fixed   drivers/misc/mediatek/video/mt6735/videox/primary_display.h
compilation error fixed   drivers/pinctrl/mediatek/pinctrl-mtk-mt6735.h
compilation error fixed   drivers/spi/mediatek/mt6735/spi-dev.c
compilation error fixed   drivers/spi/mediatek/mt6735/spi.c
compilation error fixed   drivers/watchdog/mediatek/wdt/mt6735/mtk_wdt.c